### PR TITLE
Clear up invite sent print statement

### DIFF
--- a/src/main/edu/colostate/cs/cs414/ByteMe/banqi/client/User.java
+++ b/src/main/edu/colostate/cs/cs414/ByteMe/banqi/client/User.java
@@ -54,7 +54,7 @@ public class User {
 		if (BanqiController.getUser(nickname).equals(null))
 			throw new NullPointerException("User does not exist in the Banqi system and can't be invited.");
 		Invite newInvite = new Invite(this, nickname);
-		System.out.println("Invited " + nickname + ". " + newInvite + "\n");
+		System.out.println("Invited " + nickname + " to play Banqi!\n");
 		invites.add(newInvite);
 		invitedUsers.add(nickname);
 		gamesInvitedTo.add(this.nickname);


### PR DESCRIPTION
It was definitely hard for me to see that it said Invited whoever, because it also had the invite from and time data right next to it.  I also don't think the inviting user needs to see what the invite looks like, so it seems we can leave the "from:  ___ time: ____" part out.

How about this?

57              System.out.println("Invited " + nickname + " to play Banqi!\n");